### PR TITLE
6 fix dark navbar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
 </head>
 <body>
+    <!-- LIGHT NAVBAR START -->
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <a class="navbar-brand" href="/">
             Power Strip Example
@@ -20,7 +21,7 @@
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item">
                     <a class="nav-link" href="/" title="Links somewhere in your application">
-                        Menu
+                        Light Navbar
                     </a>
                 </li>
                 <li class="nav-item">
@@ -29,9 +30,36 @@
                     </a>
                 </li>
             </ul>
-            <span id="startupapi-power-strip" class="d-flex justify-content-end"></span>
+            <span class="startupapi-power-strip" class="d-flex justify-content-end"></span>
         </div>
     </nav>
-    <!-- NAVBAR END -->
+    <!-- LIGHT NAVBAR END -->
+    <!-- DARK NAVBAR START -->
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <a class="navbar-brand" href="/">
+            Power Strip Example
+        </a>
+
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav mr-auto">
+                <li class="nav-item">
+                    <a class="nav-link" href="/" title="Links somewhere in your application">
+                        Dark Navbar
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/" title="Links somewhere in your application">
+                        About
+                    </a>
+                </li>
+            </ul>
+            <span class="startupapi-power-strip" class="d-flex justify-content-end"></span>
+        </div>
+    </nav>
+    <!-- DARK NAVBAR END -->
 </body>
 </html>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -45,9 +45,18 @@ const ConnectedPowerStrip = connect(
 store.dispatch(loadIdentity());
 store.dispatch(loadAccounts());
 
-ReactDOM.render(
-  <Provider store={store}>
-    <ConnectedPowerStrip/>
-  </Provider>,
-  document.getElementById('startupapi-power-strip')
-);
+const powerStrips = Array.from(document.querySelectorAll('.startupapi-power-strip'));
+const powerStripByID = document.getElementById('startupapi-power-strip');
+
+if (powerStripByID) {
+  powerStrips.push(powerStripByID);
+}
+
+powerStrips.forEach(element => {
+  ReactDOM.render(
+    <Provider store={store}>
+      <ConnectedPowerStrip/>
+    </Provider>,
+    element
+  );
+})

--- a/src/themes/bootstrap4/power-strip/LoggedInPowerStrip.jsx
+++ b/src/themes/bootstrap4/power-strip/LoggedInPowerStrip.jsx
@@ -10,14 +10,13 @@ export default function LoggedInPowerStrip(props) {
         const current_account = props.accounts.find(account => account.is_current);
 
         accountDropdown = <Dropdown onSelect={props.accountChangeCallback}>
-            <Dropdown.Toggle variant="plain" id="account-dropdown">
+            <Dropdown.Toggle variant="outline-secondary" id="account-dropdown">
                 {current_account.name}
             </Dropdown.Toggle>
             <Dropdown.Menu>
                 {props.accounts
-                    .filter(account => !account.is_current)
                     .map(account => (
-                    <Dropdown.Item eventKey={account.id}>{account.name}</Dropdown.Item>
+                    <Dropdown.Item eventKey={account.id} active={account.is_current}>{account.name}</Dropdown.Item>
                 ))}
             </Dropdown.Menu>
         </Dropdown>


### PR DESCRIPTION
Fixes account drop down toggle button on dark navbar by using `secondary-outline` Button variant.

Also added highlighted current account to the dropdown list to remove umbiguity.

And for debugging purposes, main HTML page now has two navbars, for light and dark variation.