### PR TITLE
Added async/await support to babel through extra runtime polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": [
+    ["@babel/preset-env", { "targets": "> 0.25%, not dead" }],
+    "@babel/preset-react"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^17.0.1",
     "react-redux": "^7.2.2",
     "redux": "^4.0.5",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "regenerator-runtime": "^0.13.7"
   }
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,6 @@
+// enables async/await
+import "regenerator-runtime/runtime.js";
+
 import React from "react";
 import ReactDOM from "react-dom";
 

--- a/src/store/accounts.js
+++ b/src/store/accounts.js
@@ -12,34 +12,29 @@ export function setCurrentAccountById(accountId) {
 }
 
 export function loadAccounts() {
-  return (dispatch) => {
+  return async (dispatch) => {
     dispatch({
       type: LOAD_ACCOUNTS,
     });
 
-    window
+    const data = await window
       .fetch("/users/api.php?call=/startupapi/v1/accounts", {
         method: "GET",
         credentials: "same-origin",
       })
       .then((response) => response.json())
-      .then((data) => {
-        if (data.meta.success) {
-          return dispatch({
-            accounts: data.result,
-            type: ACCOUNTS_LOADED,
-          });
-        } else {
-          return dispatch({
-            type: ACCOUNTS_UNKNOWN,
-          });
-        }
-      })
-      .catch(() =>
-        dispatch({
-          type: ACCOUNTS_UNKNOWN,
-        })
-      );
+      .catch(() => null);
+
+    if (data && data.meta && data.meta.success) {
+      return dispatch({
+        accounts: data.result,
+        type: ACCOUNTS_LOADED,
+      });
+    } else {
+      return dispatch({
+        type: ACCOUNTS_UNKNOWN,
+      });
+    }
   };
 }
 

--- a/src/store/identity.js
+++ b/src/store/identity.js
@@ -3,34 +3,29 @@ export const IDENTITY_LOADED = "IDENTITY_LOADED";
 export const IDENTITY_UNKNOWN = "IDENTITY_UNKNOWN";
 
 export function loadIdentity() {
-  return (dispatch) => {
+  return async (dispatch) => {
     dispatch({
       type: LOAD_IDENTITY,
     });
 
-    return window
+    const data = await window
       .fetch("/users/api.php?call=/startupapi/v1/user", {
         method: "GET",
         credentials: "same-origin",
       })
       .then((response) => response.json())
-      .then((data) => {
-        if (data.meta.success) {
-          return dispatch({
-            identity: data.result,
-            type: IDENTITY_LOADED,
-          });
-        } else {
-          return dispatch({
-            type: IDENTITY_UNKNOWN,
-          });
-        }
-      })
-      .catch(() =>
-        dispatch({
-          type: IDENTITY_UNKNOWN,
-        })
-      );
+      .catch(() => null);
+
+    if (data && data.meta && data.meta.success) {
+      return dispatch({
+        identity: data.result,
+        type: IDENTITY_LOADED,
+      });
+    } else {
+      return dispatch({
+        type: IDENTITY_UNKNOWN,
+      });
+    }
   };
 }
 


### PR DESCRIPTION
Added `regenerator-runtime` polyfill to support generators and async/await with babel.

Updated fetch code to use async/await.

Closes #15 